### PR TITLE
Add the Min and the Max range to DateTimeValidationRule.

### DIFF
--- a/WinUX.Common/Data/Validation/Rules/DateTimeValidationRule.cs
+++ b/WinUX.Common/Data/Validation/Rules/DateTimeValidationRule.cs
@@ -8,6 +8,26 @@
     public class DateTimeValidationRule : ValidationRule
     {
         /// <summary>
+        ///  Gets or sets the minimum of <see cref="DateTime"/>.
+        ///  The default value is DateTime.MinValue
+        /// </summary>
+        public DateTime MinDateTime
+        {
+            set;
+            get;
+        } = DateTime.MinValue;
+
+        /// <summary>
+        /// Gets or sets the maximum of <see cref="DateTime"/>.
+        /// The default value is DateTime.MaxValue
+        /// </summary>
+        public DateTime MaxDateTime
+        {
+            set;
+            get;
+        } = DateTime.MaxValue;
+
+        /// <summary>
         /// Validates the specified object is a <see cref="DateTime"/>.
         /// </summary>
         /// <param name="value">
@@ -27,7 +47,11 @@
             }
 
             DateTime temp;
-            return DateTime.TryParse(val, out temp);
+            if (DateTime.TryParse(val, out temp))
+            {
+                return temp >= MinDateTime && temp <= MaxDateTime;
+            }
+            return false;
         }
     }
 }

--- a/WinUX.Common/Data/Validation/ValidationRule.cs
+++ b/WinUX.Common/Data/Validation/ValidationRule.cs
@@ -13,7 +13,7 @@
         /// <remarks>
         /// The default error message is currently in English as 'Field invalid'.
         /// </remarks>
-        public string DefaultErrorMessage { set; get; } = "Field invalid.";
+        public static string DefaultErrorMessage { set; get; } = "Field invalid.";
 
         /// <summary>
         /// Gets the error message to display for the rule.
@@ -22,7 +22,7 @@
         {
             get
             {
-                return string.IsNullOrWhiteSpace(this.errorMessage) ? this.DefaultErrorMessage : this.errorMessage;
+                return string.IsNullOrWhiteSpace(this.errorMessage) ? DefaultErrorMessage : this.errorMessage;
             }
             set
             {


### PR DESCRIPTION
Add the Min and the Max range to DateTimeValidationRule.

Changed the  DefaultErrorMessage to static in the ValidationRule.The reason is the dever will set the ErrorMessage when they had set DefaultErrorMessage.I think the dever may want to set all the DefaultErrorMessage once.Just they want to set the native ErrorMessage to DefaultErrorMessage,but if the DefaultErrorMessage is not static ,it will show "Field invalid." when the dever not set all the DefaultErrorMessage.